### PR TITLE
K8s processor metric refactor

### DIFF
--- a/processor/k8sattributesprocessor/internal/kube/client.go
+++ b/processor/k8sattributesprocessor/internal/kube/client.go
@@ -377,7 +377,7 @@ func (c *WatchClient) GetPod(identifier PodIdentifier) (*Pod, bool) {
 		}
 		return pod, ok
 	}
-	observability.RecordIPLookupMiss()
+	observability.RecordIDLookupMiss()
 	return nil, false
 }
 

--- a/processor/k8sattributesprocessor/internal/observability/observability.go
+++ b/processor/k8sattributesprocessor/internal/observability/observability.go
@@ -18,7 +18,7 @@ func init() {
 		viewPodsUpdated,
 		viewPodsAdded,
 		viewPodsDeleted,
-		viewIPLookupMiss,
+		viewIDLookupMiss,
 		viewPodTableSize,
 		viewNamespacesAdded,
 		viewNamespacesUpdated,
@@ -30,20 +30,20 @@ func init() {
 }
 
 var (
-	mPodsUpdated        = stats.Int64("otelsvc/k8s/pod_updated", "Number of pod update events received", "1")
-	mPodsAdded          = stats.Int64("otelsvc/k8s/pod_added", "Number of pod add events received", "1")
-	mPodsDeleted        = stats.Int64("otelsvc/k8s/pod_deleted", "Number of pod delete events received", "1")
-	mPodTableSize       = stats.Int64("otelsvc/k8s/pod_table_size", "Size of table containing pod info", "1")
-	mIPLookupMiss       = stats.Int64("otelsvc/k8s/ip_lookup_miss", "Number of times pod by IP lookup failed.", "1")
-	mNamespacesUpdated  = stats.Int64("otelsvc/k8s/namespace_updated", "Number of namespace update events received", "1")
-	mNamespacesAdded    = stats.Int64("otelsvc/k8s/namespace_added", "Number of namespace add events received", "1")
-	mNamespacesDeleted  = stats.Int64("otelsvc/k8s/namespace_deleted", "Number of namespace delete events received", "1")
-	mNodesUpdated       = stats.Int64("otelsvc/k8s/node_updated", "Number of node update events received", "1")
-	mNodesAdded         = stats.Int64("otelsvc/k8s/node_added", "Number of node add events received", "1")
-	mNodesDeleted       = stats.Int64("otelsvc/k8s/node_deleted", "Number of node delete events received", "1")
-	mReplicaSetsUpdated = stats.Int64("otelsvc/k8s/replicaset_updated", "Number of ReplicaSet update events received", "1")
-	mReplicaSetsAdded   = stats.Int64("otelsvc/k8s/replicaset_added", "Number of ReplicaSet add events received", "1")
-	mReplicaSetsDeleted = stats.Int64("otelsvc/k8s/replicaset_deleted", "Number of ReplicaSet delete events received", "1")
+	mPodsUpdated        = stats.Int64("otelcol.k8s.pod_updated", "Number of pod update events received", "1")
+	mPodsAdded          = stats.Int64("otelcol.k8s.pod_added", "Number of pod add events received", "1")
+	mPodsDeleted        = stats.Int64("otelcol.k8s.pod_deleted", "Number of pod delete events received", "1")
+	mPodTableSize       = stats.Int64("otelcol.k8s.pod_table_size", "Size of table containing pod info", "1")
+	mIPLookupMiss       = stats.Int64("otelcol.k8s.id_lookup_miss", "Number of times pod by ID lookup failed.", "1")
+	mNamespacesUpdated  = stats.Int64("otelcol.k8s.namespace_updated", "Number of namespace update events received", "1")
+	mNamespacesAdded    = stats.Int64("otelcol.k8s.namespace_added", "Number of namespace add events received", "1")
+	mNamespacesDeleted  = stats.Int64("otelcol.k8s.namespace_deleted", "Number of namespace delete events received", "1")
+	mNodesUpdated       = stats.Int64("otelcol.k8s.node_updated", "Number of node update events received", "1")
+	mNodesAdded         = stats.Int64("otelcol.k8s.node_added", "Number of node add events received", "1")
+	mNodesDeleted       = stats.Int64("otelcol.k8s.node_deleted", "Number of node delete events received", "1")
+	mReplicaSetsUpdated = stats.Int64("otelcol.k8s.replicaset_updated", "Number of ReplicaSet update events received", "1")
+	mReplicaSetsAdded   = stats.Int64("otelcol.k8s.replicaset_added", "Number of ReplicaSet add events received", "1")
+	mReplicaSetsDeleted = stats.Int64("otelcol.k8s.replicaset_deleted", "Number of ReplicaSet delete events received", "1")
 )
 
 var viewPodsUpdated = &view.View{
@@ -67,7 +67,7 @@ var viewPodsDeleted = &view.View{
 	Aggregation: view.Sum(),
 }
 
-var viewIPLookupMiss = &view.View{
+var viewIDLookupMiss = &view.View{
 	Name:        mIPLookupMiss.Name(),
 	Description: mIPLookupMiss.Description(),
 	Measure:     mIPLookupMiss,
@@ -138,8 +138,8 @@ func RecordPodDeleted() {
 	stats.Record(context.Background(), mPodsDeleted.M(int64(1)))
 }
 
-// RecordIPLookupMiss increments the metric that records Pod lookup by IP misses.
-func RecordIPLookupMiss() {
+// RecordIDLookupMiss increments the metric that records Pod lookup by ID misses.
+func RecordIDLookupMiss() {
 	stats.Record(context.Background(), mIPLookupMiss.M(int64(1)))
 }
 

--- a/processor/k8sattributesprocessor/internal/observability/observability_test.go
+++ b/processor/k8sattributesprocessor/internal/observability/observability_test.go
@@ -61,43 +61,43 @@ func TestMetrics(t *testing.T) {
 	}
 	tests := []testCase{
 		{
-			"otelsvc/k8s/pod_added",
+			"otelcol.k8s.pod_added",
 			RecordPodAdded,
 		},
 		{
-			"otelsvc/k8s/pod_deleted",
+			"otelcol.k8s.pod_deleted",
 			RecordPodDeleted,
 		},
 		{
-			"otelsvc/k8s/pod_updated",
+			"otelcol.k8s.pod_updated",
 			RecordPodUpdated,
 		},
 		{
-			"otelsvc/k8s/ip_lookup_miss",
-			RecordIPLookupMiss,
+			"otelcol.k8s.id_lookup_miss",
+			RecordIDLookupMiss,
 		},
 		{
-			"otelsvc/k8s/namespace_added",
+			"otelcol.k8s.namespace_added",
 			RecordNamespaceAdded,
 		},
 		{
-			"otelsvc/k8s/namespace_updated",
+			"otelcol.k8s.namespace_updated",
 			RecordNamespaceUpdated,
 		},
 		{
-			"otelsvc/k8s/namespace_deleted",
+			"otelcol.k8s.namespace_deleted",
 			RecordNamespaceDeleted,
 		},
 		{
-			"otelsvc/k8s/node_added",
+			"otelcol.k8s.node_added",
 			RecordNodeAdded,
 		},
 		{
-			"otelsvc/k8s/node_updated",
+			"otelcol.k8s.node_updated",
 			RecordNodeUpdated,
 		},
 		{
-			"otelsvc/k8s/node_deleted",
+			"otelcol.k8s.node_deleted",
 			RecordNodeDeleted,
 		},
 	}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
- replace slashes(/) with underscores(_)
- rename otelsvc prefix for otelcol
- rename lookup miss metric to fit for new mechanism

**Link to tracking Issue:** #2322

**Testing:** Unit tests

**Documentation:** 